### PR TITLE
Make PEP8+Python2.7 compliant

### DIFF
--- a/trading_ig/__init__.py
+++ b/trading_ig/__init__.py
@@ -16,3 +16,8 @@ from .version import (__author__, __copyright__, __credits__, __license__,
 
 from .rest import IGService
 from .stream import IGStreamService
+
+__all__ = ['IGService', 'IGStreamService', '__author__',
+           '__copyright__', '__credits__', '__license__',
+           '__version__', '__maintainer__', '__email__',
+           '__status__', '__url__']

--- a/trading_ig/config.py
+++ b/trading_ig/config.py
@@ -9,6 +9,7 @@ CONFIG_FILE_NAME = "trading_ig_config.py"
 
 logger = logging.getLogger(__name__)
 
+
 class ConfigEnvVar(object):
     def __init__(self, env_var_base):
         self.ENV_VAR_BASE = env_var_base
@@ -18,14 +19,16 @@ class ConfigEnvVar(object):
 
     def get(self, key, default_value=None):
         env_var = self._env_var(key)
-        return(os.environ.get(_env_var, default_value))
+        return(os.environ.get(env_var, default_value))
 
     def __getattr__(self, key):
         env_var = self._env_var(key)
         try:
             return(os.environ[env_var])
         except KeyError:
-            raise Exception("Environment variable '%s' doesn't exist" % env_var)
+            raise Exception("Environment variable '%s' doesn't exist"
+                            % env_var)
+
 
 try:
     from trading_ig_config import config
@@ -34,7 +37,8 @@ except:
     logger.warning("can't import config from config file")
     try:
         config = ConfigEnvVar(ENV_VAR_ROOT)
-        logger.info("import config from environment variables '%s_...'" % ENV_VAR_ROOT)
+        logger.info("import config from environment variables '%s_...'"
+                    % ENV_VAR_ROOT)
     except:
         logger.warning("can't import config from environment variables")
         raise("""Can't import config - you might create a '%s' filename or use

--- a/trading_ig/lightstreamer.py
+++ b/trading_ig/lightstreamer.py
@@ -18,19 +18,22 @@ import logging
 import threading
 import traceback
 
-from urllib.request import urlopen as _urlopen
-from urllib.parse import (urlparse as parse_url, urljoin, urlencode)
+from six.moves.urllib.request import urlopen as _urlopen
+from six.moves.urllib.parse import (urlparse as parse_url, urljoin, urlencode)
 
 try:
     from systemd.daemon import notify
 except ImportError:
     notify = None
 
+
 def _url_encode(params):
     return urlencode(params).encode("utf-8")
 
+
 def _iteritems(d):
     return iter(d.items())
+
 
 CONNECTION_URL_PATH = "lightstreamer/create_session.txt"
 BIND_URL_PATH = "lightstreamer/bind_session.txt"
@@ -174,7 +177,8 @@ class LSClient(object):
         """
 
         if not notify:
-            log.warning("systemd.daemon not available, no watchdog notifications will be sent.")
+            log.warning("systemd.daemon not available, " +
+                        "no watchdog notifications will be sent.")
 
         self._stream_connection = self._call(
             self._base_url,
@@ -301,7 +305,8 @@ class LSClient(object):
             else:
                 log.warning("Server error")
         else:
-            log.warning("No subscription key {0} found!".format(subcription_key))
+            log.warning("No subscription key {0} found!".format(
+                        subcription_key))
 
     def _forward_update_message(self, update_message):
         """Forwards the real time update to the relative
@@ -380,6 +385,7 @@ class LSClient(object):
             log.debug("Binding to this active session")
             self.bind()
 
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
 
@@ -399,16 +405,15 @@ if __name__ == "__main__":
     subscription = Subscription(
         mode="MERGE",
         items=["item1", "item2", "item3", "item4",
-            "item5", "item6", "item7", "item8",
-            "item9", "item10", "item11", "item12"],
+               "item5", "item6", "item7", "item8",
+               "item9", "item10", "item11", "item12"],
         fields=["stock_name", "last_price", "time", "bid", "ask"],
         adapter="QUOTE_ADAPTER")
-
 
     # A simple function acting as a Subscription listener
     def on_item_update(item_update):
         print("{stock_name:<19}: Last{last_price:>6} - Time {time:<8} - "
-            "Bid {bid:>5} - Ask {ask:>5}".format(**item_update["values"]))
+              "Bid {bid:>5} - Ask {ask:>5}".format(**item_update["values"]))
 
     # Adding the "on_item_update" function to Subscription
     subscription.addlistener(on_item_update)

--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -6,7 +6,7 @@ IG Markets REST API Library for Python
 http://labs.ig.com/rest-trading-api-reference
 Original version by Lewis Barber - 2014 - http://uk.linkedin.com/in/lewisbarber/
 Modified by Femto Trader - 2014-2015 - https://github.com/femtotrader/
-"""
+""" # noqa
 
 import json
 
@@ -15,13 +15,13 @@ from requests import Session
 from .utils import (_HAS_PANDAS, _HAS_MUNCH)
 from .utils import (conv_resol, conv_datetime, conv_to_ms)
 
+
 class IGException(Exception):
     pass
 
+
 class IGSessionCRUD(object):
-    """
-    Session with CRUD operation
-    """
+    """Session with CRUD operation"""
     CLIENT_TOKEN = None
     SECURITY_TOKEN = None
 
@@ -56,7 +56,7 @@ class IGSessionCRUD(object):
         :return:
         """
         if session is None:
-            session = self.session # requests Session
+            session = self.session   # requests Session
         else:
             session = session
         return session
@@ -151,7 +151,6 @@ class IGSessionCRUD(object):
         }
 
 
-
 class IGService:
 
     D_BASE_URL = {
@@ -183,7 +182,7 @@ class IGService:
         self.return_munch = _HAS_MUNCH
 
         if session is None:
-            self.session = Session() # Requests Session (global)
+            self.session = Session()  # Requests Session (global)
         else:
             self.session = session
 
@@ -196,7 +195,7 @@ class IGService:
         for example)
         """
         if session is None:
-            session = self.session # requests Session
+            session = self.session  # requests Session
         else:
             session = session
         return session
@@ -207,7 +206,7 @@ class IGService:
         response = self.crud_session.req(action, endpoint, params, session)
         return response
 
-    ########## PARSE_RESPONSE ##########
+    # ---------- PARSE_RESPONSE ----------- #
 
     def parse_response_without_exception(self, *args, **kwargs):
         """Parses JSON response
@@ -225,11 +224,9 @@ class IGService:
             raise(Exception(response['errorCode']))
         return response
 
-    ############ END ############
+    # --------- END -------- #
 
-
-
-    ########## DATAFRAME TOOLS ##########
+    # ------ DATAFRAME TOOLS -------- #
 
     def colname_unique(self, d_cols):
         """Returns a set of column names (unique)"""
@@ -258,13 +255,11 @@ class IGService:
                     raise(NotImplementedError("col overlap: %r" % col))
         return data
 
-    ############ END ############
+    # -------- END ------- #
 
+    # -------- ACCOUNT ------- #
 
-
-    ########## ACCOUNT ##########
-
-    def fetch_accounts(self, session = None):
+    def fetch_accounts(self, session=None):
         """Returns a list of accounts belonging to the logged-in client"""
         params = {}
         endpoint = '/accounts'
@@ -275,7 +270,8 @@ class IGService:
             import pandas as pd
             data = pd.DataFrame(data['accounts'])
             d_cols = {
-                'balance': [u'available', u'balance', u'deposit', u'profitLoss']
+                'balance': [u'available', u'balance',
+                            u'deposit', u'profitLoss']
             }
             data = self.expand_columns(data, d_cols, False)
 
@@ -290,7 +286,9 @@ class IGService:
         return data
 
     def fetch_account_activity_by_period(self, milliseconds, session=None):
-        """Returns the account activity history for the last specified period"""
+        """
+        Returns the account activity history for the last specified period
+        """
         milliseconds = conv_to_ms(milliseconds)
         params = {}
         url_params = {
@@ -343,8 +341,9 @@ class IGService:
 
         return data
 
-    def fetch_transaction_history(self, trans_type=None, from_date=None, to_date=None,
-                                  max_span_seconds=None, page_size=None, page_number=None,
+    def fetch_transaction_history(self, trans_type=None, from_date=None,
+                                  to_date=None, max_span_seconds=None,
+                                  page_size=None, page_number=None,
                                   session=None):
         """Returns the transaction history for the specified transaction
         type and period"""
@@ -369,7 +368,7 @@ class IGService:
         endpoint = '/history/transactions'
         action = 'read'
 
-        self.crud_session.HEADERS['LOGGED_IN']['Version'] = 2
+        self.crud_session.HEADERS['LOGGED_IN']['Version'] = "2"
         response = self._req(action, endpoint, params, session)
         del(self.crud_session.HEADERS['LOGGED_IN']['Version'])
         data = self.parse_response(response.text)
@@ -387,11 +386,9 @@ class IGService:
 
         return data
 
-    ############ END ############
+    # -------- END -------- #
 
-
-
-    ########## DEALING ##########
+    # -------- DEALING -------- #
 
     def fetch_deal_by_deal_reference(self, deal_reference, session=None):
         """Returns a deal confirmation for the given deal reference"""
@@ -405,7 +402,7 @@ class IGService:
         data = self.parse_response(response.text)
         return data
 
-    def fetch_open_positions(self, session = None):
+    def fetch_open_positions(self, session=None):
         """Returns all open positions for the active account"""
         params = {}
         endpoint = '/positions'
@@ -419,8 +416,8 @@ class IGService:
 
             d_cols = {
                 'market': ['bid', 'delayTime', 'epic', 'expiry', 'high',
-                           'instrumentName', 'instrumentType', 'lotSize', 'low',
-                           'marketStatus', 'netChange', 'offer',
+                           'instrumentName', 'instrumentType', 'lotSize',
+                           'low', 'marketStatus', 'netChange', 'offer',
                            'percentageChange', 'scalingFactor',
                            'streamingPricesAvailable', 'updateTime'],
                 'position': ['contractSize', 'controlledRisk', 'createdDate',
@@ -461,9 +458,10 @@ class IGService:
             raise IGException(response.text)
 
     def create_open_position(self, currency_code, direction, epic, expiry,
-                             force_open, guaranteed_stop, level, limit_distance,
-                             limit_level, order_type, quote_id, size,
-                             stop_distance, stop_level, session=None):
+                             force_open, guaranteed_stop, level,
+                             limit_distance, limit_level, order_type,
+                             quote_id, size, stop_distance, stop_level,
+                             session=None):
         """Creates an OTC position"""
         params = {
             'currencyCode': currency_code,
@@ -512,7 +510,7 @@ class IGService:
         else:
             raise IGException(response.text)
 
-    def fetch_working_orders(self, session = None):
+    def fetch_working_orders(self, session=None):
         """Returns all open working orders for the active account"""
         params = {}
         endpoint = '/workingorders'
@@ -536,7 +534,8 @@ class IGService:
                                      u'currencyCode', u'contingentLimit',
                                      u'trailingTriggerIncrement', u'dealId',
                                      u'contingentStop', u'goodTill',
-                                     u'controlledRisk', u'trailingStopIncrement',
+                                     u'controlledRisk',
+                                     u'trailingStopIncrement',
                                      u'createdDate', u'epic',
                                      u'trailingTriggerDistance', u'dma']
             }
@@ -547,7 +546,8 @@ class IGService:
 
             col_overlap_allowed = ['epic']
 
-            data = self.expand_columns(data, d_cols, False, col_overlap_allowed)
+            data = self.expand_columns(data, d_cols, False,
+                                       col_overlap_allowed)
 
             # d = data.to_dict()
             # data = pd.concat(list(map(pd.DataFrame, d.values())),
@@ -563,9 +563,9 @@ class IGService:
                              good_till_date=None, deal_reference=None,
                              force_open=False, session=None):
         """Creates an OTC working order"""
-
+        VERSION = 2
         if good_till_date is not None and type(good_till_date) is not int:
-            good_till_date = conv_datetime(good_till_date, 1)
+            good_till_date = conv_datetime(good_till_date, VERSION)
 
         params = {
             'currencyCode': currency_code,
@@ -594,7 +594,7 @@ class IGService:
         endpoint = '/workingorders/otc'
         action = 'create'
 
-        self.crud_session.HEADERS['LOGGED_IN']['Version'] = 2
+        self.crud_session.HEADERS['LOGGED_IN']['Version'] = str(VERSION)
         print(params)
         response = self._req(action, endpoint, params, session)
         del(self.crud_session.HEADERS['LOGGED_IN']['Version'])
@@ -648,11 +648,9 @@ class IGService:
         else:
             raise IGException(response.text)
 
-    ############ END ############
+    # -------- END -------- #
 
-
-
-    ########## MARKETS ##########
+    # -------- MARKETS -------- #
 
     def fetch_client_sentiment_by_instrument(self, market_id, session=None):
         """Returns the client sentiment for the given instrument's market"""
@@ -699,10 +697,11 @@ class IGService:
             data['markets'] = pd.DataFrame(data['markets'])
             if len(data['markets']) == 0:
                 columns = ['bid', 'delayTime', 'epic', 'expiry', 'high',
-                           'instrumentName', 'instrumentType', 'lotSize', 'low',
-                           'marketStatus', 'netChange', 'offer', 'otcTradeable',
-                           'percentageChange', 'scalingFactor',
-                           'streamingPricesAvailable', 'updateTime']
+                           'instrumentName', 'instrumentType', 'lotSize',
+                           'low', 'marketStatus', 'netChange', 'offer',
+                           'otcTradeable', 'percentageChange',
+                           'scalingFactor', 'streamingPricesAvailable',
+                           'updateTime']
                 data['markets'] = pd.DataFrame(columns=columns)
             data['nodes'] = pd.DataFrame(data['nodes'])
             if len(data['nodes']) == 0:
@@ -809,10 +808,11 @@ class IGService:
                 'closePrice.%s' % typ: 'Close',
                 'lastTradedVolume': 'Volume'
             })
-        last = prices[0]['lastTradedVolume'] or prices[0]['closePrice']['lastTraded']
+        last = prices[0]['lastTradedVolume'] \
+            or prices[0]['closePrice']['lastTraded']
         df = json_normalize(prices)
         df = df.set_index('snapshotTime')
-        df.index = pd.to_datetime(df.index,format="%Y:%m:%d-%H:%M:%S")
+        df.index = pd.to_datetime(df.index, format="%Y:%m:%d-%H:%M:%S")
         df.index.name = 'DateTime'
 
         df_ask = df[['openPrice.ask', 'highPrice.ask',
@@ -869,7 +869,7 @@ class IGService:
             params['pageNumber'] = pagenumber
         endpoint = '/prices/' + epic
         action = 'read'
-        self.crud_session.HEADERS['LOGGED_IN']['Version'] = 3
+        self.crud_session.HEADERS['LOGGED_IN']['Version'] = "3"
         response = self._req(action, endpoint, params, session)
         del(self.crud_session.HEADERS['LOGGED_IN']['Version'])
         data = self.parse_response(response.text)
@@ -878,7 +878,8 @@ class IGService:
         return(data)
 
     def fetch_historical_prices_by_epic_and_num_points(self, epic, resolution,
-                                                       numpoints, session=None):
+                                                       numpoints,
+                                                       session=None):
         """Returns a list of historical prices for the given epic, resolution,
         number of points"""
         resolution = conv_resol(resolution)
@@ -936,11 +937,9 @@ class IGService:
             data['prices'] = self.format_prices(data['prices'])
         return data
 
-    ############ END ############
+    # -------- END -------- #
 
-
-
-    ######### WATCHLISTS ########
+    # -------- WATCHLISTS -------- #
 
     def fetch_all_watchlists(self, session=None):
         """Returns all watchlists belonging to the active account"""
@@ -1018,11 +1017,9 @@ class IGService:
         response = self._req(action, endpoint, params, session)
         return response.text
 
-    ############ END ############
+    # -------- END -------- #
 
-
-
-    ########### LOGIN ###########
+    # -------- LOGIN -------- #
 
     def logout(self, session=None):
         """Log out of the current session"""
@@ -1043,7 +1040,7 @@ class IGService:
         # this is the first create (BASIC_HEADERS)
         response = self._req(action, endpoint, params, session)
         data = self.parse_response(response.text)
-        self.ig_session = data # store IG session
+        self.ig_session = data  # store IG session
         return data
 
     def switch_account(self, account_id, default_account, session=None):
@@ -1067,11 +1064,9 @@ class IGService:
         response = self._req(action, endpoint, params, session)
         data = self.parse_response(response.text)
         return data
-    ############ END ############
+    # -------- END -------- #
 
-
-
-    ########## GENERAL ##########
+    # -------- GENERAL -------- #
 
     def get_client_apps(self, session=None):
         """Returns a list of client-owned applications"""
@@ -1109,4 +1104,4 @@ class IGService:
         data = self.parse_response(response.text)
         return data
 
-    ############ END ############
+    # -------- END -------- #

--- a/trading_ig/stream.py
+++ b/trading_ig/stream.py
@@ -11,6 +11,7 @@ from .lightstreamer import LSClient
 
 logger = logging.getLogger(__name__)
 
+
 class IGStreamService(object):
     def __init__(self, ig_service):
         self.ig_service = ig_service
@@ -26,24 +27,26 @@ class IGStreamService(object):
         cst = self.ig_service.crud_session.CLIENT_TOKEN
         xsecuritytoken = self.ig_service.crud_session.SECURITY_TOKEN
         lightstreamerEndpoint = self.ig_session[u'lightstreamerEndpoint']
-        clientId = self.ig_session[u'clientId']
+        # clientId = self.ig_session[u'clientId']
         ls_password = 'CST-%s|XST-%s' % (cst, xsecuritytoken)
 
         # Establishing a new connection to Lightstreamer Server
         logger.info("Starting connection with %s" % lightstreamerEndpoint)
-        #self.ls_client = LSClient("http://localhost:8080", "DEMO")
-        #self.ls_client = LSClient("http://push.lightstreamer.com", "DEMO")
-        self.ls_client = LSClient(lightstreamerEndpoint, adapter_set="", user=accountId, password=ls_password)
+        # self.ls_client = LSClient("http://localhost:8080", "DEMO")
+        # self.ls_client = LSClient("http://push.lightstreamer.com", "DEMO")
+        self.ls_client = LSClient(lightstreamerEndpoint, adapter_set="",
+                                  user=accountId, password=ls_password)
         try:
             self.ls_client.connect()
             return
-        except Exception as e:
+        except Exception:
             logger.error("Unable to connect to Lightstreamer Server")
             logger.error(traceback.format_exc())
             sys.exit(1)
 
     def unsubscribe_all(self):
-        subscriptions = self.ls_client._subscriptions.copy() # To avoid a RuntimeError: dictionary changed size during iteration
+        # To avoid a RuntimeError: dictionary changed size during iteration
+        subscriptions = self.ls_client._subscriptions.copy()
         for subcription_key in subscriptions:
             self.ls_client.unsubscribe(subcription_key)
 

--- a/trading_ig/utils.py
+++ b/trading_ig/utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 
+import os
 import logging
 import traceback
 import six
@@ -16,12 +17,13 @@ else:
     _HAS_PANDAS = True
 
 try:
-    from munch import munchify
+    from munch import munchify  # noqa
 except ImportError:
     _HAS_MUNCH = False
     logger.info("Can't import munch")
 else:
     _HAS_MUNCH = True
+
 
 def conv_resol(resolution):
     """Returns a string for resolution (from a Pandas)
@@ -29,12 +31,12 @@ def conv_resol(resolution):
     if _HAS_PANDAS:
         from pandas.tseries.frequencies import to_offset
         d = {
-            to_offset('1Min'):'MINUTE',
-            to_offset('2Min'):'MINUTE_2',
-            to_offset('3Min'):'MINUTE_3',
-            to_offset('5Min'):'MINUTE_5',
-            to_offset('10Min'):'MINUTE_10',
-            to_offset('15Min'):'MINUTE_15',
+            to_offset('1Min'): 'MINUTE',
+            to_offset('2Min'): 'MINUTE_2',
+            to_offset('3Min'): 'MINUTE_3',
+            to_offset('5Min'): 'MINUTE_5',
+            to_offset('10Min'): 'MINUTE_10',
+            to_offset('15Min'): 'MINUTE_15',
             to_offset('30Min'): 'MINUTE_30',
             to_offset('1H'): 'HOUR',
             to_offset('2H'): 'HOUR_2',
@@ -58,17 +60,16 @@ def conv_resol(resolution):
 def conv_datetime(dt, version=1):
     """Converts dt to string like
     version 1 = 2014:12:15-00:00:00
-    version 2 = 2014-12-15-00:00:00
+    version 2 = 2014/12/15 00:00:00
     """
     try:
         if isinstance(dt, six.string_types):
             if _HAS_PANDAS:
-                import pandas as pd
                 dt = pd.to_datetime(dt)
 
         d_formats = {
             1: "%Y:%m:%d-%H:%M:%S",
-            2: "%Y-%m-%d %H:%M:%S"
+            2: "%Y/%m/%d %H:%M:%S"
         }
         fmt = d_formats[version]
         return dt.strftime(fmt)
@@ -89,6 +90,7 @@ def conv_to_ms(td):
         logger.error(traceback.format_exc())
         logger.warning("conv_to_ms returns '%s'" % td)
         return td
+
 
 def remove(cache):
     """Remove cache"""


### PR DESCRIPTION
- Uses six in lightstreamer.py to make it Python2.7 compliant
- Changes in date format of function conv_datetime in utils.py to make it work correctly with API
- In rest.py change version datatype in the assigment of `self.crud_session.HEADERS['LOGGED_IN']['Version']` from integer to string to prevent errors while checking headers datatype
- General format changes in all files to make it PEP8 compliant
Tested with python 3.5.3 and 2.7.13
Note: please check the change in the method get of class configEnvar in config.py.