### PR TITLE
Break out of accounts loop when a user is found

### DIFF
--- a/sample/stream_ig.py
+++ b/sample/stream_ig.py
@@ -38,6 +38,7 @@ def main():
     for account in accounts:
         if account[u'accountId'] == config.acc_number:
             accountId = account[u'accountId']
+            break
         else:
             print('Account not found: {0}'.format(config.acc_number))
             accountId = None

--- a/sample/stream_ig.py
+++ b/sample/stream_ig.py
@@ -45,7 +45,7 @@ def main():
     ig_stream_service.connect(accountId)
 
     # Making a new Subscription in MERGE mode
-    subcription_prices = Subscription(
+    subscription_prices = Subscription(
         mode="MERGE",
         items=['L1:CS.D.GBPUSD.CFD.IP', 'L1:CS.D.USDJPY.CFD.IP'],
         fields=["UPDATE_TIME", "BID", "OFFER", "CHANGE", "MARKET_STATE"],
@@ -54,10 +54,10 @@ def main():
 
 
     # Adding the "on_price_update" function to Subscription
-    subcription_prices.addlistener(on_prices_update)
+    subscription_prices.addlistener(on_prices_update)
 
     # Registering the Subscription
-    sub_key_prices = ig_stream_service.ls_client.subscribe(subcription_prices)
+    sub_key_prices = ig_stream_service.ls_client.subscribe(subscription_prices)
 
 
     # Making an other Subscription in MERGE mode


### PR DESCRIPTION
- Break when user is found. Prevents issue when loop continues and results in accountId being set to None.

- Typo fix for "subscription"