### PR TITLE
Improve not-found handling on working order creation.

### DIFF
--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -12,6 +12,10 @@ import json
 
 from requests import Session
 
+import logging
+logger = logging.getLogger(__name__)
+import time
+
 from .utils import (_HAS_PANDAS, _HAS_MUNCH)
 from .utils import (conv_resol, conv_datetime, conv_to_ms)
 
@@ -398,7 +402,13 @@ class IGService:
         }
         endpoint = '/confirms/{deal_reference}'.format(**url_params)
         action = 'read'
-        response = self._req(action, endpoint, params, session)
+        for i in range(5):
+            response = self._req(action, endpoint, params, session)
+            if response.status_code == 404:
+                logger.info("Deal reference %s not found, retrying." % deal_reference)
+                time.sleep(1)
+            else:
+                break
         data = self.parse_response(response.text)
         return data
 


### PR DESCRIPTION
Confirmations are not guaranteed to be processed immediately, and thus
may not be available immediately after order creation. It is
recommended to subscribe to TRADES:CONFIRMS or by polling /conrims
REST API. The confirms are only available for up to 1 minute, thus
implement polling inline/synchronously. Usually, the trades confirm
without a poll, or after just one poll.