### PR TITLE
When a session is created, raise exception if HTTP error response (#41)

### DIFF
--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -76,9 +76,7 @@ class IGSessionCRUD(object):
         response = session.post(url,
                                 data=json.dumps(params),
                                 headers=self.HEADERS['BASIC'])
-        if response.ok:
-            pass
-        else:
+        if not response.ok:
             raise(Exception("HTTP status code %s %s " %
                             (response.status_code, response.text)))
         self._set_headers(response.headers, True)

--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -76,6 +76,11 @@ class IGSessionCRUD(object):
         response = session.post(url,
                                 data=json.dumps(params),
                                 headers=self.HEADERS['BASIC'])
+        if response.ok:
+            pass
+        else:
+            raise(Exception("HTTP status code %s %s " %
+                            (response.status_code, response.text)))
         self._set_headers(response.headers, True)
         self.create = self._create_logged_in
         return response


### PR DESCRIPTION
This patch raises an immediate exception with the full IG error message.  Currently the exception raised is "key error : cst" during _set_headers().