### PR TITLE
Validate datatype if session argument is passed (#52)

### DIFF
--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -206,6 +206,9 @@ class IGService:
         if session is None:
             session = self.session  # requests Session
         else:
+            assert(isinstance(session, Session)), \
+                "session must be <requests.session.Session object> not %s" \
+                % type(session)
             session = session
         return session
 


### PR DESCRIPTION
if session is specified and is an incorrect datatype , then a very misleading **get() takes no keyword arguments** error is raised.

This patch validates the session datatype, if it is passed as an argument.

