### PR TITLE
[IMP] Improve fetch multiple client sentiment markets

### DIFF
--- a/trading_ig/lightstreamer.py
+++ b/trading_ig/lightstreamer.py
@@ -395,7 +395,7 @@ if __name__ == "__main__":
     lightstreamer_client = LSClient("http://push.lightstreamer.com", "DEMO")
     try:
         lightstreamer_client.connect()
-    except Exception as e:
+    except Exception as _:
         print("Unable to connect to Lightstreamer Server")
         print(traceback.format_exc())
         import sys

--- a/trading_ig/lightstreamer.py
+++ b/trading_ig/lightstreamer.py
@@ -395,7 +395,7 @@ if __name__ == "__main__":
     lightstreamer_client = LSClient("http://push.lightstreamer.com", "DEMO")
     try:
         lightstreamer_client.connect()
-    except Exception as _:
+    except Exception:
         print("Unable to connect to Lightstreamer Server")
         print(traceback.format_exc())
         import sys

--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -680,7 +680,8 @@ class IGService:
             url_params = {
                 'market_ids': market_ids
             }
-            endpoint = '/clientsentiment/?marketIds={market_ids}'.format(**url_params)
+            endpoint = '/clientsentiment/?marketIds={market_ids}'.\
+                format(**url_params)
         else:
             url_params = {
                 'market_id': market_id

--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -682,10 +682,10 @@ class IGService:
             }
             endpoint = '/clientsentiment/?marketIds={market_ids}'.format(**url_params)
         else:
-	    url_params = {
-	        'market_id': market_id
-	    }
-	    endpoint = '/clientsentiment/{market_id}'.format(**url_params)
+            url_params = {
+                'market_id': market_id
+            }
+            endpoint = '/clientsentiment/{market_id}'.format(**url_params)
         action = 'read'
         response = self._req(action, endpoint, params, session)
         data = self.parse_response(response.text)

--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -675,10 +675,17 @@ class IGService:
     def fetch_client_sentiment_by_instrument(self, market_id, session=None):
         """Returns the client sentiment for the given instrument's market"""
         params = {}
-        url_params = {
-            'market_id': market_id
-        }
-        endpoint = '/clientsentiment/{market_id}'.format(**url_params)
+        if isinstance(market_id, (list,)):
+            market_ids = ','.join(market_id)
+            url_params = {
+                'market_ids': market_ids
+            }
+            endpoint = '/clientsentiment/?marketIds={market_ids}'.format(**url_params)
+        else:
+	    url_params = {
+	        'market_id': market_id
+	    }
+	    endpoint = '/clientsentiment/{market_id}'.format(**url_params)
         action = 'read'
         response = self._req(action, endpoint, params, session)
         data = self.parse_response(response.text)


### PR DESCRIPTION
you can send python list with multiple market designation to have all the result in one shoot

    fetch_client_sentiment_by_instrument(marke_id)
    where >> market_id = ['WALL','FT100',EURUSD']