### PR TITLE
Format prices using different REST response versions.

### DIFF
--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -16,7 +16,7 @@ import logging
 import time
 
 from .utils import (_HAS_PANDAS, _HAS_MUNCH)
-from .utils import (conv_resol, conv_datetime, conv_to_ms)
+from .utils import (conv_resol, conv_datetime, conv_to_ms, DATE_FORMATS)
 
 
 logger = logging.getLogger(__name__)
@@ -833,7 +833,7 @@ class IGService:
         prices['volume'] = ts_lastTradedVolume
         return prices
 
-    def format_prices(self, prices, flag_calc_spread=False):
+    def format_prices(self, prices, version, flag_calc_spread=False):
         """Format prices data as a DataFrame with hierarchical columns"""
 
         if len(prices) == 0:
@@ -854,7 +854,7 @@ class IGService:
             or prices[0]['closePrice']['lastTraded']
         df = json_normalize(prices)
         df = df.set_index('snapshotTime')
-        df.index = pd.to_datetime(df.index, format="%Y:%m:%d-%H:%M:%S")
+        df.index = pd.to_datetime(df.index, format=DATE_FORMATS[int(version)])
         df.index.name = 'DateTime'
 
         df_ask = df[['openPrice.ask', 'highPrice.ask',
@@ -893,7 +893,8 @@ class IGService:
                                         numpoints=None,
                                         pagesize=0,
                                         pagenumber=None,
-                                        session=None):
+                                        session=None,
+                                        version="3"):
         """Returns a list of historical prices for the given epic, resolution,
         number of points"""
         params = {}
@@ -911,17 +912,18 @@ class IGService:
             params['pageNumber'] = pagenumber
         endpoint = '/prices/' + epic
         action = 'read'
-        self.crud_session.HEADERS['LOGGED_IN']['Version'] = "3"
+        self.crud_session.HEADERS['LOGGED_IN']['Version'] = str(version)
         response = self._req(action, endpoint, params, session)
         del(self.crud_session.HEADERS['LOGGED_IN']['Version'])
         data = self.parse_response(response.text)
         if _HAS_PANDAS and self.return_dataframe:
-            data['prices'] = self.format_prices(data['prices'])
+            data['prices'] = self.format_prices(data['prices'], version)
         return(data)
 
     def fetch_historical_prices_by_epic_and_num_points(self, epic, resolution,
                                                        numpoints,
-                                                       session=None):
+                                                       session=None,
+                                                       version="1"):
         """Returns a list of historical prices for the given epic, resolution,
         number of points"""
         if _HAS_PANDAS and self.return_dataframe:
@@ -935,15 +937,18 @@ class IGService:
         endpoint = '/prices/{epic}/{resolution}/{numpoints}'.\
             format(**url_params)
         action = 'read'
+        self.crud_session.HEADERS['LOGGED_IN']['Version'] = str(version)
         response = self._req(action, endpoint, params, session)
+        del(self.crud_session.HEADERS['LOGGED_IN']['Version'])
         data = self.parse_response(response.text)
         if _HAS_PANDAS and self.return_dataframe:
-            data['prices'] = self.format_prices(data['prices'])
+            data['prices'] = self.format_prices(data['prices'], version)
         return(data)
 
     def fetch_historical_prices_by_epic_and_date_range(self, epic, resolution,
                                                        start_date, end_date,
-                                                       session=None):
+                                                       session=None,
+                                                       version="1"):
         """Returns a list of historical prices for the given epic, resolution,
         multiplier and date range"""
         if _HAS_PANDAS and self.return_dataframe:
@@ -975,10 +980,12 @@ class IGService:
         }
         endpoint = "/prices/{epic}/{resolution}".format(**url_params)
         action = 'read'
+        self.crud_session.HEADERS['LOGGED_IN']['Version'] = str(version)
         response = self._req(action, endpoint, params, session)
+        del(self.crud_session.HEADERS['LOGGED_IN']['Version'])
         data = self.parse_response(response.text)
         if _HAS_PANDAS and self.return_dataframe:
-            data['prices'] = self.format_prices(data['prices'])
+            data['prices'] = self.format_prices(data['prices'], version)
         return data
 
     # -------- END -------- #

--- a/trading_ig/utils.py
+++ b/trading_ig/utils.py
@@ -25,6 +25,13 @@ else:
     _HAS_MUNCH = True
 
 
+DATE_FORMATS = {
+    1: "%Y:%m:%d-%H:%M:%S",
+    2: "%Y/%m/%d %H:%M:%S",
+    3: "%Y/%m/%d %H:%M:%S"
+}
+
+
 def conv_resol(resolution):
     """Returns a string for resolution (from a Pandas)
     """
@@ -61,17 +68,14 @@ def conv_datetime(dt, version=1):
     """Converts dt to string like
     version 1 = 2014:12:15-00:00:00
     version 2 = 2014/12/15 00:00:00
+    version 3 = 2014/12/15 00:00:00
     """
     try:
         if isinstance(dt, six.string_types):
             if _HAS_PANDAS:
                 dt = pd.to_datetime(dt)
 
-        d_formats = {
-            1: "%Y:%m:%d-%H:%M:%S",
-            2: "%Y/%m/%d %H:%M:%S"
-        }
-        fmt = d_formats[version]
+        fmt = DATE_FORMATS[int(version)]
         return dt.strftime(fmt)
     except (ValueError, TypeError):
         logger.error(traceback.format_exc())


### PR DESCRIPTION
This PR fixes the issue of formatting the prices that might have a different date format. 
For instance, date responses in v2/v3 have this format '2014/12/15 00:00:00', whereas v1 dates are formatted as '2014:12:15-00:00:00'.

It also allows to specify the REST format version for each epic function.