### PR TITLE
Issue#82 Encrypt password during login.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+*.swp
 
 # C extensions
 *.so

--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -78,6 +78,7 @@ class IGSessionCRUD(object):
         """Create first = POST with headers=BASIC_HEADERS"""
         url = self._url(endpoint)
         session = self._get_session(session)
+        params['password'] = params['password'].decode()
         response = session.post(url,
                                 data=json.dumps(params),
                                 headers=self.HEADERS['BASIC'])
@@ -1097,7 +1098,8 @@ class IGService:
         """Encrypt password for login"""
         key, timestamp = self.get_encryption_key(session)
         rsakey = RSA.importKey(b64decode(key))
-        message = b64encode(self.IG_PASSWORD + '|' + str(long(timestamp)))
+        string = self.IG_PASSWORD + '|' + str(int(timestamp))
+        message = b64encode(string.encode())
         return b64encode(PKCS1_v1_5.new(rsakey).encrypt(message))
 
     def create_session(self, session=None, encryption=False):
@@ -1106,7 +1108,7 @@ class IGService:
         password = self.encrypted_password(session) if encryption else self.IG_PASSWORD
         params = {
             'identifier': self.IG_USERNAME,
-            'password':   password
+            'password': password
         }
         if encryption: params['encryptedPassword'] = True
         endpoint = '/session'

--- a/trading_ig/stream.py
+++ b/trading_ig/stream.py
@@ -18,8 +18,8 @@ class IGStreamService(object):
         self.ig_session = None
         self.ls_client = None
 
-    def create_session(self):
-        ig_session = self.ig_service.create_session()
+    def create_session(self, encryption=False):
+        ig_session = self.ig_service.create_session(encryption=encryption)
         self.ig_session = ig_session
         return ig_session
 


### PR DESCRIPTION
The IG API in some countries require an encrypted password during login. Otherwise you'll get an error **error.public-api.failure.encryption.required**. We get the encryption key first, then create session with the encrypted password.

Use the optional parameter **encryption=True** to enable this feature
```
from trading_ig import IGService
from trading_ig.config import config

ig_service = IGService(config.username, config.password, config.api_key, config.acc_type)
ig_service.create_session(encryption=True)
```