### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/technical.html#install-requires-vs-requirements-files
     install_requires=[
+        "pycryptodome",
         "pandas",
         "requests",
         "requests-cache",


### PR DESCRIPTION
fixes "ModuleNotFoundError: No module named 'Crypto'" error