### PR TITLE
Add pycroptodome to support calls to Crypto made in rest.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
         "requests-cache",
         "six",
         "munch",
+        "pycryptodome",
     ],  # bunch->lunch->infi.bunch->munch
     # List additional groups of dependencies here (e.g. development dependencies).
     # You can install these using the following syntax, for example:


### PR DESCRIPTION
As title says, in rest.py we import Crypto.Cipher and Crypto.PublicKey but the associated package is not part of the standard set up.