### PR TITLE
b64encode return byte object causing json.dump failed

### DIFF
--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -1238,7 +1238,7 @@ class IGService:
         rsakey = RSA.importKey(b64decode(key))
         string = self.IG_PASSWORD + "|" + str(int(timestamp))
         message = b64encode(string.encode())
-        return b64encode(PKCS1_v1_5.new(rsakey).encrypt(message))
+        return b64encode(PKCS1_v1_5.new(rsakey).encrypt(message)).decode()
 
     def create_session(self, session=None, encryption=False):
         """Creates a trading session, obtaining session tokens for


### PR DESCRIPTION
When calling `ig_service.create_session(encryption=True)` , I received 
`TypeError: Object of type bytes is not JSON serializable` from

```
trading-ig\trading_ig\rest.py in _create_logged_in(self, endpoint, params, session, version)
     99         self.HEADERS["LOGGED_IN"]["VERSION"] = version
    100         response = session.post(
--> 101             url, data=json.dumps(params), headers=self.HEADERS["LOGGED_IN"]
    102         )
    103         return response
```

Based on Py3 doc, [b64encode](https://docs.python.org/3/library/base64.html#base64.b64encode) returns byte object and json library unable to process byte object.
Converting it immediately to string during the encryption process, will solve the issue in the json encoding.