### PR TITLE
More fixes to fetch_historical_prices_by_epic

### DIFF
--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -1038,7 +1038,7 @@ class IGService:
         start_date=None,
         end_date=None,
         numpoints=None,
-        pagesize=0,
+        pagesize=20,
         pagenumber=None,
         session=None,
         format=None
@@ -1056,8 +1056,7 @@ class IGService:
             params["to"] = end_date
         if numpoints:
             params["max"] = numpoints
-        if pagesize:
-            params["pageSize"] = pagesize
+        params["pageSize"] = pagesize
         if pagenumber:
             params["pageNumber"] = pagenumber
         url_params = {"epic": epic}


### PR DESCRIPTION
Per the IG Labs documentation, pagesize is 20 by default and can be set to 0 to disable pagination.

Currently, fetch_historical_prices_by_epic defaults pagesize to 0 but then ignores it if it is 0, making it impossible to disable pagination.