### PR TITLE
fixed sample account lookup bug and got scripts working in sample directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ Pipfile.lock
 # env
 .github/.env
 .python-version
+
+.vscode

--- a/sample/rest_ig.py
+++ b/sample/rest_ig.py
@@ -6,6 +6,10 @@ IG Markets REST API sample with Python
 2015 FemtoTrader
 """
 
+import sys
+
+sys.path.append('.') # required for scripts to run in the "sample" directory
+# pylint: disable=import-error
 from trading_ig import IGService
 from trading_ig.config import config
 import logging

--- a/sample/stream_ig.py
+++ b/sample/stream_ig.py
@@ -11,10 +11,11 @@ import sys
 import traceback
 import logging
 
+sys.path.append('.') # required for scripts to run in the "sample" directory
+# pylint: disable=import-error
 from trading_ig import IGService, IGStreamService
 from trading_ig.config import config
 from trading_ig.lightstreamer import Subscription
-
 
 # A simple function acting as a Subscription listener
 def on_prices_update(item_update):
@@ -41,15 +42,22 @@ def main():
 
     ig_stream_service = IGStreamService(ig_service)
     ig_session = ig_stream_service.create_session()
+
     # Ensure configured account is selected
+    accountId = None
+    account_list = []
     accounts = ig_session[u"accounts"]
     for account in accounts:
         if account[u"accountId"] == config.acc_number:
             accountId = account[u"accountId"]
             break
-        else:
-            print("Account not found: {0}".format(config.acc_number))
-            accountId = None
+        account_list.append(account[u"accountId"])
+
+    if accountId is None:
+        print("Account not found: {0}".format(config.acc_number))
+        print("Available accounts:", account_list)
+        sys.exit()
+
     ig_stream_service.connect(accountId)
 
     # Making a new Subscription in MERGE mode

--- a/sample/stream_stock_list_demo.py
+++ b/sample/stream_stock_list_demo.py
@@ -17,8 +17,10 @@
 import sys
 import traceback
 import logging
-from trading_ig.lightstreamer import LSClient, Subscription
 
+sys.path.append('.')
+# pylint: disable=import-error
+from trading_ig.lightstreamer import LSClient, Subscription
 
 # A simple function acting as a Subscription listener
 def on_item_update(item_update):
@@ -81,7 +83,7 @@ def main():
     # Unsubscribing from Lightstreamer by using the subscription key
     # lightstreamer_client.unsubscribe(sub_key)
 
-    lightstreamer_client.unsubscribe()
+    lightstreamer_client.unsubscribe(sub_key)
 
     # Disconnecting
     lightstreamer_client.disconnect()

--- a/trading_ig/config.py
+++ b/trading_ig/config.py
@@ -28,7 +28,6 @@ class ConfigEnvVar(object):
         except KeyError:
             raise Exception("Environment variable '%s' doesn't exist" % env_var)
 
-
 try:
     from trading_ig_config import config
 


### PR DESCRIPTION
I fixed the following bugs:

1. In the "sample" directory the config lookup failed as it was not finding "trading_ig_config.py" in the current directory when it is located one level up.

2. The "trading_ig" library inclusion in the "sample" directory was failing because it was looking in the current directory instead of one level up.

3. The lightstreamer unsubscribe was missing an argument which I added.

4. Fixed an account lookup issue. It was checking if the first account returned was matching with the config and if not then failing with an error. In my case there are multiple accounts so it needed to finish interating through the accounts to see if there was a match.

The streaming samples still don't return any results for me. I'm looking into that but at least the scripts run now without having to set the environment variables which is insecure. 