### PR TITLE
Adopt to API changes in tenacity, Update rest.py

### DIFF
--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -199,7 +199,7 @@ class IGService:
         Wraps the _request() function, applying a tenacity.Retrying object if configured
         """
         if self._retryer is not None:
-            result = self._retryer.call(self._request, action, endpoint, params, session, version, check)
+            result = self._retryer(self._request, action, endpoint, params, session, version, check)
         else:
             result = self._request(action, endpoint, params, session, version, check)
 


### PR DESCRIPTION
The call method has been removed from latest release, https://tenacity.readthedocs.io/en/latest/changelog.html
It seems one should do like this instead.