### PR TITLE
fix for http error 405 response from ig when confirming deal

### DIFF
--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -704,7 +704,7 @@ class IGService:
         action = "read"
         for i in range(5):
             response = self._req(action, endpoint, params, session, version)
-            if response.status_code == 404:
+            if response.status_code == 404 or response.status_code == 405:
                 logger.info("Deal reference %s not found, retrying." % deal_reference)
                 time.sleep(1)
             else:


### PR DESCRIPTION
Every now and then, I get a 405 response when confirming a deal after create_open_position(). Every time this has happened, the position has opened correctly. It is just the confirmation that has caused problems.

`INFO POST '/positions/otc', resp 200`
`INFO GET '/confirms/XA6########YM9', resp 405`
followed by:
`json.decoder.JSONDecodeError exception: Expecting value: line 1 column 1 (char 0)`
because of parse_response().

This should fix it.