### PR TITLE
Added leaky bucket rate limiter

### DIFF
--- a/tests/data/application.json
+++ b/tests/data/application.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "TEST_APPLICATION",
+  
+    "apiKey": "123456789abcdef123456789abcdef1234567890",
+    "status": "ENABLED",
+    "allowanceApplicationOverall": 60,
+    "allowanceAccountTrading": 100,
+    "allowanceAccountOverall": 30,
+    "allowanceAccountHistoricalData": 10000,
+    "concurrentSubscriptionsLimit": 40,
+    "allowEquities": false,
+    "allowQuoteOrders": false,
+    "createdDate": "2015-01-01"
+  }
+]

--- a/tests/data/markets_epic.json
+++ b/tests/data/markets_epic.json
@@ -1,0 +1,135 @@
+{
+  "instrument": {
+    "epic": "CO.D.CFI.Month2.IP",
+    "expiry": "DEC-24",
+    "name": "Carbon Emissions",
+    "forceOpenAllowed": true,
+    "stopsLimitsAllowed": true,
+    "lotSize": 1.0,
+    "unit": "AMOUNT",
+    "type": "COMMODITIES",
+    "controlledRiskAllowed": true,
+    "streamingPricesAvailable": true,
+    "marketId": "CFI",
+    "currencies": [
+      {
+        "code": "EUR",
+        "symbol": "E",
+        "baseExchangeRate": 1.195885,
+        "exchangeRate": 0.81,
+        "isDefault": false
+      },
+      {
+        "code": "GBP",
+        "symbol": "£",
+        "baseExchangeRate": 1.0,
+        "exchangeRate": 1.0,
+        "isDefault": true
+      }
+    ],
+    "sprintMarketsMinimumExpiryTime": null,
+    "sprintMarketsMaximumExpiryTime": null,
+    "marginDepositBands": [
+      {
+        "min": 0,
+        "max": 495,
+        "margin": 10,
+        "currency": "EUR"
+      },
+      {
+        "min": 495,
+        "max": 990,
+        "margin": 15,
+        "currency": "EUR"
+      },
+      {
+        "min": 990,
+        "max": 2722.5,
+        "margin": 20,
+        "currency": "EUR"
+      },
+      {
+        "min": 2722.5,
+        "max": null,
+        "margin": 30,
+        "currency": "EUR"
+      }
+    ],
+    "marginFactor": 10,
+    "marginFactorUnit": "PERCENTAGE",
+    "slippageFactor": {
+      "unit": "pct",
+      "value": 50.0
+    },
+    "limitedRiskPremium": {
+      "value": 30,
+      "unit": "POINTS"
+    },
+    "openingHours": {
+      "marketTimes": [
+        {
+          "openTime": "07:00",
+          "closeTime": "17:00"
+        }
+      ]
+    },
+    "expiryDetails": {
+      "lastDealingDate": "2024-12-16T17:00",
+      "settlementInfo": "Settles based on the official settlement price of the ICE ECX Carbon Emissions future on the last dealing day +/- IG dealing spread."
+    },
+    "rolloverDetails": {
+      "lastRolloverTime": "2024-12-16T16:45",
+      "rolloverInfo": "Usually, initial position closed at official closing level of day before last dealing day +/- closing spread; new position in next contract opened at official closing level of the new contract from same day, +/-  opening spread."
+    },
+    "newsCode": "CO2",
+    "chartCode": null,
+    "country": null,
+    "valueOfOnePip": null,
+    "onePipMeans": null,
+    "contractSize": null,
+    "specialInfo": [ "MAX KNOCK OUT LEVEL DISTANCE", "DEFAULT KNOCK OUT LEVEL DISTANCE" ]
+  },
+  "dealingRules": {
+    "minStepDistance": {
+      "unit": "POINTS",
+      "value": 1.0
+    },
+    "minDealSize": {
+      "unit": "POINTS",
+      "value": 0.25
+    },
+    "minControlledRiskStopDistance": {
+      "unit": "PERCENTAGE",
+      "value": 10.0
+    },
+    "minNormalStopOrLimitDistance": {
+      "unit": "POINTS",
+      "value": 10.0
+    },
+    "maxStopOrLimitDistance": {
+      "unit": "PERCENTAGE",
+      "value": 75.0
+    },
+    "controlledRiskSpacing": {
+      "unit": "POINTS",
+      "value": 10.0
+    },
+    "marketOrderPreference": "AVAILABLE_DEFAULT_OFF",
+    "trailingStopsPreference": "AVAILABLE"
+  },
+  "snapshot": {
+    "marketStatus": "OFFLINE",
+    "netChange": 324,
+    "percentageChange": 3.76,
+    "updateTime": "16:59:55",
+    "delayTime": 0,
+    "bid": 8933.0,
+    "offer": 8939.0,
+    "high": 9022.0,
+    "low": 7487.0,
+    "binaryOdds": null,
+    "decimalPlacesFactor": 1,
+    "scalingFactor": 1,
+    "controlledRiskExtraSpread": 30
+  }
+}

--- a/tests/data/markets_epic.json
+++ b/tests/data/markets_epic.json
@@ -21,7 +21,7 @@
       },
       {
         "code": "GBP",
-        "symbol": "£",
+        "symbol": "Â£",
         "baseExchangeRate": 1.0,
         "exchangeRate": 1.0,
         "isDefault": true

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,74 @@
+from trading_ig.rest import IGService
+import responses
+import json
+import time
+
+"""
+unit tests for rate limiter
+"""
+
+
+class TestRateLimiter:
+
+    @responses.activate
+    def test_rate_limiter_non_trading_req(self):
+
+        with open('tests/data/session.json', 'r') as file:
+            session_response_body = json.loads(file.read())
+
+        responses.add(responses.POST, 'https://demo-api.ig.com/gateway/deal/session',
+                      headers={'CST': 'abc123', 'X-SECURITY-TOKEN': 'xyz987'},
+                      json=session_response_body,
+                      status=200)
+        responses.add(responses.GET, 'https://demo-api.ig.com/gateway/deal/session',
+                      headers={'CST': 'abc123', 'X-SECURITY-TOKEN': 'xyz987'},
+                      json=session_response_body,
+                      status=200)
+
+        with open('tests/data/application.json', 'r') as file:
+            app_response_body = json.loads(file.read())
+
+        responses.add(responses.POST, 'https://demo-api.ig.com/gateway/deal/operations/application',
+                      headers={'CST': 'abc123', 'X-SECURITY-TOKEN': 'xyz987'},
+                      json=app_response_body,
+                      status=200)
+        responses.add(responses.GET, 'https://demo-api.ig.com/gateway/deal/operations/application',
+                      headers={'CST': 'abc123', 'X-SECURITY-TOKEN': 'xyz987'},
+                      json=app_response_body,
+                      status=200)
+
+        with open('tests/data/markets_epic.json', 'r') as file:
+            mkts_epic_response_body = json.loads(file.read())
+
+        responses.add(responses.POST, 'https://demo-api.ig.com/gateway/deal/markets/CO.D.CFI.Month2.IP',
+                      headers={'CST': 'abc123', 'X-SECURITY-TOKEN': 'xyz987'},
+                      json=mkts_epic_response_body,
+                      status=200)
+        responses.add(responses.GET, 'https://demo-api.ig.com/gateway/deal/markets/CO.D.CFI.Month2.IP',
+                      headers={'CST': 'abc123', 'X-SECURITY-TOKEN': 'xyz987'},
+                      json=mkts_epic_response_body,
+                      status=200)
+
+        ig_service = IGService('username', 'password', 'api_key', 'DEMO', use_rate_limiter=True)
+
+        ig_service.create_session()
+
+        # empty the bucket queue (len=1), before we start timing things
+        ig_service.fetch_market_by_epic('CO.D.CFI.Month2.IP')
+
+        times = []
+        for i in range(3):
+            time_last = time.time()
+            ig_service.fetch_market_by_epic('CO.D.CFI.Month2.IP')
+            times.append(time.time() - time_last)
+
+        ig_service.logout()
+
+        av_time = sum(times) / len(times)
+
+        expected_av = 60.0 / app_response_body[0]['allowanceAccountOverall']
+
+        time_tolerance = 0.2
+
+        assert av_time >= expected_av
+        assert av_time < expected_av + time_tolerance

--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -159,7 +159,8 @@ class IGService:
         session=None,
         return_dataframe=_HAS_PANDAS,
         return_munch=_HAS_MUNCH,
-        retryer=None
+        retryer=None,
+        use_rate_limiter = False
     ):
         """Constructor, calls the method required to connect to
         the API (accepts acc_type = LIVE or DEMO)"""
@@ -168,7 +169,8 @@ class IGService:
         self.IG_PASSWORD = password
         self.ACC_NUMBER = acc_number
         self._retryer = retryer
-
+        self._use_rate_limiter = use_rate_limiter
+        self._bucket_threads_run = False
         try:
             self.BASE_URL = self.D_BASE_URL[acc_type.lower()]
         except Exception:
@@ -191,6 +193,9 @@ class IGService:
         for acc in data:
             if acc['apiKey'] == self.API_KEY:
                 break
+
+        # If self.create_session() is called a second time, we should exit any currently running threads
+        self._exit_bucket_threads()
 
         # Horrific magic number to reduce API published allowable requests per minute to a
         # value that wont result in 403 -> error.public-api.exceeded-account-trading-allowance
@@ -243,18 +248,34 @@ class IGService:
             self._non_trading_requests_queue.put(True, block=True)
         return
 
-    def trading_rate_limit_pause(self, ):
-        self._trading_requests_queue.get(block=True)
-        self._trading_times.append(time.time())
-        self._trading_times = [req_time for req_time in self._trading_times if req_time > time.time()-60]
-        logging.info(f'Number of trading requests in last 60 seonds = {len(self._trading_times)}')
+    def trading_rate_limit_pause_or_pass(self, ):
+        if self._use_rate_limiter:
+            self._trading_requests_queue.get(block=True)
+            self._trading_times.append(time.time())
+            self._trading_times = [req_time for req_time in self._trading_times if req_time > time.time()-60]
+            logging.info(f'Number of trading requests in last 60 seonds = {len(self._trading_times)}')
+        return
 
-    def non_trading_rate_limit_pause(self, ):
-        self._non_trading_requests_queue.get(block=True)
-        self._non_trading_times.append(time.time())
-        self._non_trading_times = [req_time for req_time in self._non_trading_times if req_time > time.time()-60]
-        logging.info(f'Number of non trading requests in last 60 seonds = {len(self._non_trading_times)}')
+    def non_trading_rate_limit_pause_or_pass(self, ):
+        if self._use_rate_limiter:
+            self._non_trading_requests_queue.get(block=True)
+            self._non_trading_times.append(time.time())
+            self._non_trading_times = [req_time for req_time in self._non_trading_times if req_time > time.time()-60]
+            logging.info(f'Number of non trading requests in last 60 seonds = {len(self._non_trading_times)}')
+        return
 
+    def _exit_bucket_threads(self,):
+        if self._use_rate_limiter:
+            if self._bucket_threads_run:
+                self._bucket_threads_run = False
+                try:
+                    self._trading_requests_queue.get(block=False)
+                except Empty:
+                    pass
+                try:
+                    self._non_trading_requests_queue.get(block=False)
+                except Empty:
+                    pass
     def _get_session(self, session):
         """Returns a Requests session (from self.session) if session is None
         or session if it's not None (cached session with requests-cache
@@ -354,7 +375,7 @@ class IGService:
 
     def fetch_accounts(self, session=None):
         """Returns a list of accounts belonging to the logged-in client"""
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "1"
         params = {}
         endpoint = "/accounts"
@@ -397,7 +418,7 @@ class IGService:
         :return: preference values
         :rtype: dict
         """
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "1"
         params = {}
         endpoint = "/accounts/preferences"
@@ -416,7 +437,7 @@ class IGService:
         :return: status of the update request
         :rtype: str
         """
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "1"
         params = {}
         endpoint = "/accounts/preferences"
@@ -430,7 +451,7 @@ class IGService:
         """
         Returns the account activity history for the last specified period
         """
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "1"
         milliseconds = conv_to_ms(milliseconds)
         params = {}
@@ -458,7 +479,7 @@ class IGService:
         """
         Returns the account activity history for period between the specified dates
         """
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "1"
         if from_date is None or to_date is None:
             raise IGException("Both from_date and to_date must be specified")
@@ -518,7 +539,7 @@ class IGService:
         :return: results set
         :rtype: Pandas DataFrame if configured, otherwise a dict
         """
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "2"
         params = {}
         if from_date:
@@ -587,7 +608,7 @@ class IGService:
         :return: results set
         :rtype: Pandas DataFrame if configured, otherwise a dict
         """
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "3"
         params = {}
         if from_date:
@@ -680,7 +701,7 @@ class IGService:
     ):
         """Returns the transaction history for the specified transaction
         type and period"""
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "1"
         milliseconds = conv_to_ms(milliseconds)
         params = {}
@@ -726,7 +747,7 @@ class IGService:
     ):
         """Returns the transaction history for the specified transaction
         type and period"""
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "2"
         params = {}
         if trans_type:
@@ -781,7 +802,7 @@ class IGService:
 
     def fetch_deal_by_deal_reference(self, deal_reference, session=None):
         """Returns a deal confirmation for the given deal reference"""
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "1"
         params = {}
         url_params = {"deal_reference": deal_reference}
@@ -799,7 +820,7 @@ class IGService:
 
     def fetch_open_position_by_deal_id(self, deal_id, session=None):
         """Return the open position by deal id for the active account"""
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "2"
         params = {}
         url_params = {"deal_id": deal_id}
@@ -825,7 +846,7 @@ class IGService:
         :return: table of position data, one per row
         :rtype: pd.Dataframe
         """
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         params = {}
         endpoint = "/positions"
         action = "read"
@@ -879,7 +900,7 @@ class IGService:
         session=None,
     ):
         """Closes one or more OTC positions"""
-        self.trading_rate_limit_pause()
+        self.trading_rate_limit_pause_or_pass()
         version = "1"
         params = {
             "dealId": deal_id,
@@ -922,7 +943,7 @@ class IGService:
         session=None,
     ):
         """Creates an OTC position"""
-        self.trading_rate_limit_pause()
+        self.trading_rate_limit_pause_or_pass()
         version = "2"
         params = {
             "currencyCode": currency_code,
@@ -966,7 +987,7 @@ class IGService:
             session=None,
             version='2'):
         """Updates an OTC position"""
-        self.trading_rate_limit_pause()
+        self.trading_rate_limit_pause_or_pass()
         params = {}
         if limit_level is not None:
             params["limitLevel"] = limit_level
@@ -994,7 +1015,7 @@ class IGService:
 
     def fetch_working_orders(self, session=None, version='2'):
         """Returns all open working orders for the active account"""
-        self.non_trading_rate_limit_pause()  # ?? maybe considered trading request
+        self.non_trading_rate_limit_pause_or_pass()  # ?? maybe considered trading request
         params = {}
         endpoint = "/workingorders"
         action = "read"
@@ -1075,7 +1096,7 @@ class IGService:
         session=None,
     ):
         """Creates an OTC working order"""
-        self.trading_rate_limit_pause()
+        self.trading_rate_limit_pause_or_pass()
         version = "2"
         if good_till_date is not None and type(good_till_date) is not int:
             good_till_date = conv_datetime(good_till_date, version)
@@ -1119,7 +1140,7 @@ class IGService:
 
     def delete_working_order(self, deal_id, session=None):
         """Deletes an OTC working order"""
-        self.trading_rate_limit_pause()
+        self.trading_rate_limit_pause_or_pass()
         version = "2"
         params = {}
         url_params = {"deal_id": deal_id}
@@ -1148,7 +1169,7 @@ class IGService:
         session=None,
     ):
         """Updates an OTC working order"""
-        self.trading_rate_limit_pause()
+        self.trading_rate_limit_pause_or_pass()
         version = "2"
         if good_till_date is not None and type(good_till_date) is not int:
             good_till_date = conv_datetime(good_till_date, version)
@@ -1180,7 +1201,7 @@ class IGService:
 
     def fetch_client_sentiment_by_instrument(self, market_id, session=None):
         """Returns the client sentiment for the given instrument's market"""
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "1"
         params = {}
         if isinstance(market_id, (list,)):
@@ -1200,7 +1221,7 @@ class IGService:
     def fetch_related_client_sentiment_by_instrument(self, market_id, session=None):
         """Returns a list of related (also traded) client sentiment for
         the given instrument's market"""
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "1"
         params = {}
         url_params = {"market_id": market_id}
@@ -1215,7 +1236,7 @@ class IGService:
     def fetch_top_level_navigation_nodes(self, session=None):
         """Returns all top-level nodes (market categories) in the market
         navigation hierarchy."""
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "1"
         params = {}
         endpoint = "/marketnavigation"
@@ -1260,7 +1281,7 @@ class IGService:
     def fetch_sub_nodes_by_node(self, node, session=None):
         """Returns all sub-nodes of the given node in the market
         navigation hierarchy"""
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "1"
         params = {}
         url_params = {"node": node}
@@ -1276,7 +1297,7 @@ class IGService:
 
     def fetch_market_by_epic(self, epic, session=None):
         """Returns the details of the given market"""
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "3"
         params = {}
         url_params = {"epic": epic}
@@ -1303,7 +1324,7 @@ class IGService:
         :return: list of market details
         :rtype: Munch instance if configured, else dict
         """
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         params = {"epics": epics}
         if version == '2':
             params["filter"] = 'ALL' if detailed else 'SNAPSHOT_ONLY'
@@ -1319,7 +1340,7 @@ class IGService:
 
     def search_markets(self, search_term, session=None):
         """Returns all markets matching the search term"""
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "1"
         endpoint = "/markets"
         params = {"searchTerm": search_term}
@@ -1610,7 +1631,7 @@ class IGService:
 
     def fetch_all_watchlists(self, session=None):
         """Returns all watchlists belonging to the active account"""
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "1"
         params = {}
         endpoint = "/watchlists"
@@ -1623,7 +1644,7 @@ class IGService:
 
     def create_watchlist(self, name, epics, session=None):
         """Creates a watchlist"""
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "1"
         params = {"name": name, "epics": epics}
         endpoint = "/watchlists"
@@ -1634,7 +1655,7 @@ class IGService:
 
     def delete_watchlist(self, watchlist_id, session=None):
         """Deletes a watchlist"""
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "1"
         params = {}
         url_params = {"watchlist_id": watchlist_id}
@@ -1646,7 +1667,7 @@ class IGService:
 
     def fetch_watchlist_markets(self, watchlist_id, session=None):
         """Returns the given watchlist's markets"""
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "1"
         params = {}
         url_params = {"watchlist_id": watchlist_id}
@@ -1660,7 +1681,7 @@ class IGService:
 
     def add_market_to_watchlist(self, watchlist_id, epic, session=None):
         """Adds a market to a watchlist"""
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "1"
         params = {"epic": epic}
         url_params = {"watchlist_id": watchlist_id}
@@ -1672,7 +1693,7 @@ class IGService:
 
     def remove_market_from_watchlist(self, watchlist_id, epic, session=None):
         """Remove a market from a watchlist"""
-        self.non_trading_rate_limit_pause()
+        self.non_trading_rate_limit_pause_or_pass()
         version = "1"
         params = {}
         url_params = {"watchlist_id": watchlist_id, "epic": epic}
@@ -1694,18 +1715,7 @@ class IGService:
         action = "delete"
         self._req(action, endpoint, params, session, version)
         self.session.close()
-
-        self._bucket_threads_run = False
-
-        try:
-            self._trading_requests_queue.get(block=False)
-        except Empty:
-            pass
-
-        try:
-            self._non_trading_requests_queue.get(block=False)
-        except Empty:
-            pass
+        self._exit_bucket_threads()
 
     def get_encryption_key(self, session=None):
         """Get encryption key to encrypt the password"""
@@ -1754,7 +1764,8 @@ class IGService:
         self._manage_headers(response)
         data = self.parse_response(response.text)
 
-        self.setup_rate_limiter()
+        if self._use_rate_limiter:
+            self.setup_rate_limiter()
 
         return data
 

--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -215,6 +215,7 @@ class IGService:
         [self._trading_requests_queue.put(True) for i in range(trading_requests_burst)] # prefill the bucket so we can burst
         token_bucket_trading_thread = Thread(target=self._token_bucket_trading,)
         token_bucket_trading_thread.start()
+        self._trading_times = []
 
         # Create a leaky token bucket for non-trading requests
         non_trading_requests_burst = 1 # # If IG ever allow bursting, increase this
@@ -241,6 +242,9 @@ class IGService:
 
     def trading_rate_limit_pause(self, ):
         self._trading_requests_queue.get(block=True)
+        self._trading_times.append(time.time())
+        self._trading_times = [req_time for req_time in self._trading_times if req_time > time.time()-60]
+        logging.info(f'Number of trading requests in last 60 seonds = {len(self._trading_times)}')
 
     def non_trading_rate_limit_pause(self, ):
         self._non_trading_requests_queue.get(block=True)

--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -29,6 +29,9 @@ if _HAS_PANDAS:
     from .utils import pd, np
     from pandas import json_normalize
 
+from threading import Thread
+from queue import Queue
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +87,7 @@ class IGSessionCRUD(object):
         response = session.post(url, data=json.dumps(params))
         logging.info(f"POST '{endpoint}', resp {response.status_code}")
         if response.status_code in [401, 403]:
+            
             if 'exceeded-api-key-allowance' in response.text:
                 raise ApiExceededException()
             else:
@@ -157,7 +161,7 @@ class IGService:
         session=None,
         return_dataframe=_HAS_PANDAS,
         return_munch=_HAS_MUNCH,
-        retryer=None
+        retryer=None,
     ):
         """Constructor, calls the method required to connect to
         the API (accepts acc_type = LIVE or DEMO)"""
@@ -182,6 +186,69 @@ class IGService:
             self.session = session
 
         self.crud_session = IGSessionCRUD(self.BASE_URL, self.API_KEY, self.session)
+
+    def setup_rate_limiter(self, ):
+
+        data = self.get_client_apps()
+        for acc in data:
+            if acc['apiKey'] == self.API_KEY:
+                break
+
+        # Horific magic number to reduce API published allowable requests per minute to a 
+        # value that wont result in 403 -> error.public-api.exceeded-account-trading-allowance
+        # Tested for non_trading = 30 (live) and 10 (demo) requests per minute.
+        # This wouldn't be needed if IG's API functioned as published!
+        MAGIC_NUMBER = 2    
+
+        self._trading_requests_per_minute = acc['allowanceAccountTrading'] - MAGIC_NUMBER
+        logging.info(f"Published IG Trading Request limits for trading request: {acc['allowanceAccountTrading']} per minute. Using: {self._trading_requests_per_minute}")
+
+        self._non_trading_requests_per_minute = acc['allowanceAccountOverall'] - MAGIC_NUMBER
+        logging.info(f"Published IG Trading Request limits for non-trading request: {acc['allowanceAccountOverall']} per minute. Using {self._non_trading_requests_per_minute}")
+
+        time.sleep(60.0 / self._non_trading_requests_per_minute)
+
+        self._bucket_threads_run = True # Thread exit variable
+
+        # Create a leaky token bucket for trading requests
+        trading_requests_burst = 1 # If IG ever allow bursting, increase this
+        self._trading_requests_queue = Queue(trading_requests_burst)
+        [self._trading_requests_queue.put(True) for i in range(trading_requests_burst)] # prefill the bucket so we can burst
+        token_bucket_trading_thread = Thread(target=self._token_bucket_trading,)
+        token_bucket_trading_thread.start()
+
+        # Create a leaky token bucket for non-trading requests
+        non_trading_requests_burst = 1 # # If IG ever allow bursting, increase this
+        self._non_trading_requests_queue = Queue(non_trading_requests_burst)
+        [self._non_trading_requests_queue.put(True) for i in range(non_trading_requests_burst)] # prefill the bucket so we can burst
+        token_bucket_non_trading_thread = Thread(target=self._token_bucket_non_trading,)
+        token_bucket_non_trading_thread.start()
+        self._non_trading_times = []
+
+        # TODO
+        # Create a leaky token bucket for allowanceAccountHistoricalData 
+
+    def _token_bucket_trading(self, ):
+        while self._bucket_threads_run:
+            time.sleep(60.0/self._trading_requests_per_minute)
+            self._trading_requests_queue.put(True, block=True)
+        return
+    
+    def _token_bucket_non_trading(self, ):
+        while self._bucket_threads_run:
+            time.sleep(60.0/self._non_trading_requests_per_minute)
+            self._non_trading_requests_queue.put(True, block=True)
+        return
+
+    def trading_rate_limit_pause(self, ):
+        self._trading_requests_queue.get(block=True)
+
+    def non_trading_rate_limit_pause(self, ):
+        self._non_trading_requests_queue.get(block=True)
+        self._non_trading_times.append(time.time())
+        self._non_trading_times = [req_time for req_time in self._non_trading_times if req_time > time.time()-60]
+        logging.info(f'Number of non trading requests in last 60 seonds = {len(self._non_trading_times)}')
+
 
     def _get_session(self, session):
         """Returns a Requests session (from self.session) if session is None
@@ -282,6 +349,7 @@ class IGService:
 
     def fetch_accounts(self, session=None):
         """Returns a list of accounts belonging to the logged-in client"""
+        self.non_trading_rate_limit_pause()
         version = "1"
         params = {}
         endpoint = "/accounts"
@@ -324,6 +392,7 @@ class IGService:
         :return: preference values
         :rtype: dict
         """
+        self.non_trading_rate_limit_pause()
         version = "1"
         params = {}
         endpoint = "/accounts/preferences"
@@ -342,6 +411,7 @@ class IGService:
         :return: status of the update request
         :rtype: str
         """
+        self.non_trading_rate_limit_pause()
         version = "1"
         params = {}
         endpoint = "/accounts/preferences"
@@ -355,6 +425,7 @@ class IGService:
         """
         Returns the account activity history for the last specified period
         """
+        self.non_trading_rate_limit_pause()
         version = "1"
         milliseconds = conv_to_ms(milliseconds)
         params = {}
@@ -382,6 +453,7 @@ class IGService:
         """
         Returns the account activity history for period between the specified dates
         """
+        self.non_trading_rate_limit_pause()
         version = "1"
         if from_date is None or to_date is None:
             raise IGException("Both from_date and to_date must be specified")
@@ -441,7 +513,7 @@ class IGService:
         :return: results set
         :rtype: Pandas DataFrame if configured, otherwise a dict
         """
-
+        self.non_trading_rate_limit_pause()
         version = "2"
         params = {}
         if from_date:
@@ -510,7 +582,7 @@ class IGService:
         :return: results set
         :rtype: Pandas DataFrame if configured, otherwise a dict
         """
-
+        self.non_trading_rate_limit_pause()
         version = "3"
         params = {}
         if from_date:
@@ -603,6 +675,7 @@ class IGService:
     ):
         """Returns the transaction history for the specified transaction
         type and period"""
+        self.non_trading_rate_limit_pause()
         version = "1"
         milliseconds = conv_to_ms(milliseconds)
         params = {}
@@ -648,6 +721,7 @@ class IGService:
     ):
         """Returns the transaction history for the specified transaction
         type and period"""
+        self.non_trading_rate_limit_pause()
         version = "2"
         params = {}
         if trans_type:
@@ -702,6 +776,7 @@ class IGService:
 
     def fetch_deal_by_deal_reference(self, deal_reference, session=None):
         """Returns a deal confirmation for the given deal reference"""
+        self.non_trading_rate_limit_pause()
         version = "1"
         params = {}
         url_params = {"deal_reference": deal_reference}
@@ -719,6 +794,7 @@ class IGService:
 
     def fetch_open_position_by_deal_id(self, deal_id, session=None):
         """Return the open position by deal id for the active account"""
+        self.non_trading_rate_limit_pause()
         version = "2"
         params = {}
         url_params = {"deal_id": deal_id}
@@ -744,6 +820,7 @@ class IGService:
         :return: table of position data, one per row
         :rtype: pd.Dataframe
         """
+        self.non_trading_rate_limit_pause()
         params = {}
         endpoint = "/positions"
         action = "read"
@@ -797,6 +874,7 @@ class IGService:
         session=None,
     ):
         """Closes one or more OTC positions"""
+        self.trading_rate_limit_pause()
         version = "1"
         params = {
             "dealId": deal_id,
@@ -839,6 +917,7 @@ class IGService:
         session=None,
     ):
         """Creates an OTC position"""
+        self.trading_rate_limit_pause()
         version = "2"
         params = {
             "currencyCode": currency_code,
@@ -882,6 +961,7 @@ class IGService:
             session=None,
             version='2'):
         """Updates an OTC position"""
+        self.trading_rate_limit_pause()
         params = {}
         if limit_level is not None:
             params["limitLevel"] = limit_level
@@ -909,6 +989,7 @@ class IGService:
 
     def fetch_working_orders(self, session=None, version='2'):
         """Returns all open working orders for the active account"""
+        self.non_trading_rate_limit_pause() # ?? maybe considered trading request
         params = {}
         endpoint = "/workingorders"
         action = "read"
@@ -989,6 +1070,7 @@ class IGService:
         session=None,
     ):
         """Creates an OTC working order"""
+        self.trading_rate_limit_pause()
         version = "2"
         if good_till_date is not None and type(good_till_date) is not int:
             good_till_date = conv_datetime(good_till_date, version)
@@ -1032,6 +1114,7 @@ class IGService:
 
     def delete_working_order(self, deal_id, session=None):
         """Deletes an OTC working order"""
+        self.trading_rate_limit_pause()
         version = "2"
         params = {}
         url_params = {"deal_id": deal_id}
@@ -1060,6 +1143,7 @@ class IGService:
         session=None,
     ):
         """Updates an OTC working order"""
+        self.trading_rate_limit_pause()
         version = "2"
         if good_till_date is not None and type(good_till_date) is not int:
             good_till_date = conv_datetime(good_till_date, version)
@@ -1091,6 +1175,7 @@ class IGService:
 
     def fetch_client_sentiment_by_instrument(self, market_id, session=None):
         """Returns the client sentiment for the given instrument's market"""
+        self.non_trading_rate_limit_pause()
         version = "1"
         params = {}
         if isinstance(market_id, (list,)):
@@ -1110,6 +1195,7 @@ class IGService:
     def fetch_related_client_sentiment_by_instrument(self, market_id, session=None):
         """Returns a list of related (also traded) client sentiment for
         the given instrument's market"""
+        self.non_trading_rate_limit_pause()
         version = "1"
         params = {}
         url_params = {"market_id": market_id}
@@ -1124,6 +1210,7 @@ class IGService:
     def fetch_top_level_navigation_nodes(self, session=None):
         """Returns all top-level nodes (market categories) in the market
         navigation hierarchy."""
+        self.non_trading_rate_limit_pause()
         version = "1"
         params = {}
         endpoint = "/marketnavigation"
@@ -1168,6 +1255,7 @@ class IGService:
     def fetch_sub_nodes_by_node(self, node, session=None):
         """Returns all sub-nodes of the given node in the market
         navigation hierarchy"""
+        self.non_trading_rate_limit_pause()
         version = "1"
         params = {}
         url_params = {"node": node}
@@ -1183,6 +1271,7 @@ class IGService:
 
     def fetch_market_by_epic(self, epic, session=None):
         """Returns the details of the given market"""
+        self.non_trading_rate_limit_pause()
         version = "3"
         params = {}
         url_params = {"epic": epic}
@@ -1209,6 +1298,7 @@ class IGService:
         :return: list of market details
         :rtype: Munch instance if configured, else dict
         """
+        self.non_trading_rate_limit_pause()
         params = {"epics": epics}
         if version == '2':
             params["filter"] = 'ALL' if detailed else 'SNAPSHOT_ONLY'
@@ -1224,6 +1314,7 @@ class IGService:
 
     def search_markets(self, search_term, session=None):
         """Returns all markets matching the search term"""
+        self.non_trading_rate_limit_pause()
         version = "1"
         endpoint = "/markets"
         params = {"searchTerm": search_term}
@@ -1514,6 +1605,7 @@ class IGService:
 
     def fetch_all_watchlists(self, session=None):
         """Returns all watchlists belonging to the active account"""
+        self.non_trading_rate_limit_pause()
         version = "1"
         params = {}
         endpoint = "/watchlists"
@@ -1526,6 +1618,7 @@ class IGService:
 
     def create_watchlist(self, name, epics, session=None):
         """Creates a watchlist"""
+        self.non_trading_rate_limit_pause()
         version = "1"
         params = {"name": name, "epics": epics}
         endpoint = "/watchlists"
@@ -1536,6 +1629,7 @@ class IGService:
 
     def delete_watchlist(self, watchlist_id, session=None):
         """Deletes a watchlist"""
+        self.non_trading_rate_limit_pause()
         version = "1"
         params = {}
         url_params = {"watchlist_id": watchlist_id}
@@ -1547,6 +1641,7 @@ class IGService:
 
     def fetch_watchlist_markets(self, watchlist_id, session=None):
         """Returns the given watchlist's markets"""
+        self.non_trading_rate_limit_pause()
         version = "1"
         params = {}
         url_params = {"watchlist_id": watchlist_id}
@@ -1560,6 +1655,7 @@ class IGService:
 
     def add_market_to_watchlist(self, watchlist_id, epic, session=None):
         """Adds a market to a watchlist"""
+        self.non_trading_rate_limit_pause()
         version = "1"
         params = {"epic": epic}
         url_params = {"watchlist_id": watchlist_id}
@@ -1571,6 +1667,7 @@ class IGService:
 
     def remove_market_from_watchlist(self, watchlist_id, epic, session=None):
         """Remove a market from a watchlist"""
+        self.non_trading_rate_limit_pause()
         version = "1"
         params = {}
         url_params = {"watchlist_id": watchlist_id, "epic": epic}
@@ -1592,6 +1689,18 @@ class IGService:
         action = "delete"
         self._req(action, endpoint, params, session, version)
         self.session.close()
+
+        self._bucket_threads_run = False
+
+        try:
+            self._trading_requests_queue.get(block=False)
+        except:
+            pass
+
+        try:
+            self._non_trading_requests_queue.get(block=False)
+        except:
+            pass
 
     def get_encryption_key(self, session=None):
         """Get encryption key to encrypt the password"""
@@ -1639,6 +1748,9 @@ class IGService:
         response = self._req(action, endpoint, params, session, version, check=False)
         self._manage_headers(response)
         data = self.parse_response(response.text)
+
+        self.setup_rate_limiter()
+
         return data
 
     def refresh_session(self, session=None, version='1'):

--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -160,7 +160,7 @@ class IGService:
         return_dataframe=_HAS_PANDAS,
         return_munch=_HAS_MUNCH,
         retryer=None,
-        use_rate_limiter = False
+        use_rate_limiter=False
     ):
         """Constructor, calls the method required to connect to
         the API (accepts acc_type = LIVE or DEMO)"""
@@ -235,6 +235,7 @@ class IGService:
 
         # TODO
         # Create a leaky token bucket for allowanceAccountHistoricalData
+        return
 
     def _token_bucket_trading(self, ):
         while self._bucket_threads_run:
@@ -253,7 +254,8 @@ class IGService:
             self._trading_requests_queue.get(block=True)
             self._trading_times.append(time.time())
             self._trading_times = [req_time for req_time in self._trading_times if req_time > time.time()-60]
-            logging.info(f'Number of trading requests in last 60 seonds = {len(self._trading_times)}')
+            logging.info(f'Number of trading requests in last 60 seonds = '
+                         f'{len(self._trading_times)} of {self._trading_requests_per_minute}')
         return
 
     def non_trading_rate_limit_pause_or_pass(self, ):
@@ -261,7 +263,8 @@ class IGService:
             self._non_trading_requests_queue.get(block=True)
             self._non_trading_times.append(time.time())
             self._non_trading_times = [req_time for req_time in self._non_trading_times if req_time > time.time()-60]
-            logging.info(f'Number of non trading requests in last 60 seonds = {len(self._non_trading_times)}')
+            logging.info(f'Number of non trading requests in last 60 seonds = '
+                         f'{len(self._non_trading_times)} of {self._non_trading_requests_per_minute}')
         return
 
     def _exit_bucket_threads(self,):
@@ -276,6 +279,8 @@ class IGService:
                     self._non_trading_requests_queue.get(block=False)
                 except Empty:
                     pass
+        return
+
     def _get_session(self, session):
         """Returns a Requests session (from self.session) if session is None
         or session if it's not None (cached session with requests-cache

--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -10,7 +10,6 @@ Modified by Femto Trader - 2014-2015 - https://github.com/femtotrader/
 
 import json
 import logging
-import queue
 import time
 from base64 import b64encode, b64decode
 
@@ -193,7 +192,7 @@ class IGService:
             if acc['apiKey'] == self.API_KEY:
                 break
 
-        # Horific magic number to reduce API published allowable requests per minute to a
+        # Horrific magic number to reduce API published allowable requests per minute to a
         # value that wont result in 403 -> error.public-api.exceeded-account-trading-allowance
         # Tested for non_trading = 30 (live) and 10 (demo) requests per minute.
         # This wouldn't be needed if IG's API functioned as published!

--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -87,7 +87,6 @@ class IGSessionCRUD(object):
         response = session.post(url, data=json.dumps(params))
         logging.info(f"POST '{endpoint}', resp {response.status_code}")
         if response.status_code in [401, 403]:
-            
             if 'exceeded-api-key-allowance' in response.text:
                 raise ApiExceededException()
             else:
@@ -161,7 +160,7 @@ class IGService:
         session=None,
         return_dataframe=_HAS_PANDAS,
         return_munch=_HAS_MUNCH,
-        retryer=None,
+        retryer=None
     ):
         """Constructor, calls the method required to connect to
         the API (accepts acc_type = LIVE or DEMO)"""

--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -30,7 +30,7 @@ if _HAS_PANDAS:
     from pandas import json_normalize
 
 from threading import Thread
-from queue import Queue
+from queue import Queue, Empty
 
 logger = logging.getLogger(__name__)
 
@@ -1699,12 +1699,12 @@ class IGService:
 
         try:
             self._trading_requests_queue.get(block=False)
-        except queue.Empty:
+        except Empty:
             pass
 
         try:
             self._non_trading_requests_queue.get(block=False)
-        except queue.Empty:
+        except Empty:
             pass
 
     def get_encryption_key(self, session=None):


### PR DESCRIPTION
Added a leaky bucket rate limiter that limits the number of request per minute for trading and non-trading requests to the limits published by the API... minus 2, because the API doesn't function as published.

Creates a couple of threads that each fill a queue at the allowable rate. Before making a request, a blocking get is called, which will pause until a token is released.

If IG ever allow bursting, that can easily be accommodated by increasing the length of the queue.

Worth checking the correct queue gets checked for trading/non-trading requests.

Tenacity is still needed.

Seems fairly solid and should result in an overall speed improvement, though not fully tested with all request types.