### PR TITLE
new fix for jsondecode error

### DIFF
--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -858,12 +858,12 @@ class IGService:
         for i in range(5):
             response = self._req(action, endpoint, params, session, version)
             if not response.status_code == 200:
-                logger.info("Deal id %s not found, retrying." % deal_id)
+                logger.info("Error fetching open positions, retrying.")
                 time.sleep(1)
             else:
                 break
         data = self.parse_response(response.text)
-        
+
         if self.return_dataframe:
 
             list = data["positions"]

--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -815,7 +815,7 @@ class IGService:
         action = "read"
         for i in range(5):
             response = self._req(action, endpoint, params, session, version)
-            if response.status_code == 404:
+            if not response.status_code == 200:
                 logger.info("Deal reference %s not found, retrying." % deal_reference)
                 time.sleep(1)
             else:
@@ -833,7 +833,7 @@ class IGService:
         action = "read"
         for i in range(5):
             response = self._req(action, endpoint, params, session, version)
-            if response.status_code == 404:
+            if not response.status_code == 200:
                 logger.info("Deal id %s not found, retrying." % deal_id)
                 time.sleep(1)
             else:
@@ -855,8 +855,15 @@ class IGService:
         params = {}
         endpoint = "/positions"
         action = "read"
-        response = self._req(action, endpoint, params, session, version)
+        for i in range(5):
+            response = self._req(action, endpoint, params, session, version)
+            if not response.status_code == 200:
+                logger.info("Deal id %s not found, retrying." % deal_id)
+                time.sleep(1)
+            else:
+                break
         data = self.parse_response(response.text)
+        
         if self.return_dataframe:
 
             list = data["positions"]


### PR DESCRIPTION
Hi, last year I made PR https://github.com/ig-python/ig-markets-api-python-library/pull/237 to handle the problem of JSONDecodeError when IG responds with HTTP 405 error. The PR was accepted, but I can see now that the changes were reverted by @bug-or-feature in commit 2c708a4de0d7ab5d646eeee0373b70b418399a36.

What was the reason for reverting the code?

If it was by mistake, I have a new PR here with some additional improvements.