### PR TITLE
fix unit test for 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ pytest = "^6.2"
 responses = "^0.12"
 coveralls = "^3.2"
 sphinx-rtd-theme = {version = "^1.0.0", optional = true}
+importlib-metadata = "==4.13.0"
 
 [tool.poetry.urls]
 "Issues" = "https://github.com/ig-python/ig-markets-api-python-library/issues"


### PR DESCRIPTION
specify transitive dependency 'importlib-metadata' to 4.13.0 to prevent flake8 problems with python 3.7