### PR TITLE
Convert column list from set to list.

### DIFF
--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -350,10 +350,9 @@ class IGService:
     def colname_unique(d_cols):
         """Returns a set of column names (unique)"""
         s = set()
-        for _, lst in d_cols.items():
-            for colname in lst:
-                s.add(colname)
-        return s
+        for lst in d_cols.values():
+            s.update(lst)
+        return list(s)
 
     @staticmethod
     def expand_columns(data, d_cols, flag_col_prefix=False, col_overlap_allowed=None):
@@ -866,8 +865,8 @@ class IGService:
 
         if self.return_dataframe:
 
-            list = data["positions"]
-            data = pd.DataFrame(list)
+            lst = data["positions"]
+            data = pd.DataFrame(lst)
 
             cols = {
                 "position": [


### PR DESCRIPTION
From version 1.5.0, Pandas no longer allows `set` object for the `index` or `columns` arguments of the `DataFrame` constructor. This PR converts the `set` to a `list` in `colname_unique` to accommodate this change.

Unfortunately, I do not have an IG account, so I could not run all unit tests.